### PR TITLE
Fix code scanning alert no. 1: Prototype-polluting function

### DIFF
--- a/autogpt_platform/frontend/src/lib/utils.ts
+++ b/autogpt_platform/frontend/src/lib/utils.ts
@@ -141,13 +141,20 @@ export function setNestedProperty(obj: any, path: string, value: any) {
 
   for (let i = 0; i < keys.length - 1; i++) {
     const key = keys[i];
+    if (key === "__proto__" || key === "constructor" || key === "prototype") {
+      return; // Prevent prototype pollution
+    }
     if (!current[key] || typeof current[key] !== "object") {
       current[key] = {};
     }
     current = current[key];
   }
 
-  current[keys[keys.length - 1]] = value;
+  const finalKey = keys[keys.length - 1];
+  if (finalKey === "__proto__" || finalKey === "constructor" || finalKey === "prototype") {
+    return; // Prevent prototype pollution
+  }
+  current[finalKey] = value;
 }
 
 export function removeEmptyStringsAndNulls(obj: any): any {


### PR DESCRIPTION
Fixes [https://github.com/aka2024/AutoGPT/security/code-scanning/1](https://github.com/aka2024/AutoGPT/security/code-scanning/1)

To fix the problem, we need to ensure that the function `setNestedProperty` does not allow setting properties that can lead to prototype pollution. This can be achieved by adding checks to block the `__proto__`, `constructor`, and `prototype` properties.

- Modify the `setNestedProperty` function to include checks that prevent setting these special properties.
- Ensure that these checks are applied both when creating nested objects and when setting the final property.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
